### PR TITLE
Add API integration with backend

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,56 @@
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://13.125.148.30:8080';
+
+async function apiRequest(path, options = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    credentials: 'include',
+    ...options,
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+export const getQnaList = (page = 0, size = 10) =>
+  apiRequest(`/api/qna?page=${page}&size=${size}`);
+export const getQna = (id) => apiRequest(`/api/qna/${id}`);
+export const postQna = (data) =>
+  apiRequest('/api/qna', { method: 'POST', body: JSON.stringify(data) });
+export const updateQna = (id, data) =>
+  apiRequest(`/api/qna/${id}`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteQna = (id) =>
+  apiRequest(`/api/qna/${id}`, { method: 'DELETE' });
+export const answerQna = (id, answer) =>
+  apiRequest(`/api/qna/${id}/answer`, {
+    method: 'PUT',
+    body: JSON.stringify({ answer }),
+  });
+
+export const signup = (data) =>
+  apiRequest('/api/signup', { method: 'POST', body: JSON.stringify(data) });
+export const login = (data) =>
+  apiRequest('/api/login', { method: 'POST', body: JSON.stringify(data) });
+
+export const getNoticeList = (page = 0, size = 10) =>
+  apiRequest(`/api/notices?page=${page}&size=${size}`);
+export const getNotice = (id) => apiRequest(`/api/notices/${id}`);
+export const createNotice = (data) =>
+  apiRequest('/api/notices', { method: 'POST', body: JSON.stringify(data) });
+export const updateNotice = (id, data) =>
+  apiRequest(`/api/notices/${id}`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteNotice = (id) =>
+  apiRequest(`/api/notices/${id}`, { method: 'DELETE' });
+
+export const askChatbot = (question) =>
+  apiRequest('/api/chatbot/question', {
+    method: 'POST',
+    body: JSON.stringify({ question }),
+  });
+
+export default apiRequest;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,5 +1,6 @@
 // src/pages/Login.jsx
 import React, { useState } from "react";
+import { login } from "../api";
 import {
   LoginWrapper,
   LoginCard,
@@ -23,9 +24,15 @@ export default function Login() {
   const [id, setId] = useState("");
   const [pw, setPw] = useState("");
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log({ id, pw });
+    try {
+      await login({ email: id, password: pw });
+      alert("로그인 성공");
+    } catch (err) {
+      console.error(err);
+      alert("로그인 실패");
+    }
   };
 
   return (

--- a/src/pages/Signup.js
+++ b/src/pages/Signup.js
@@ -1,5 +1,6 @@
 // src/pages/Signup.jsx
 import React, { useState } from "react";
+import { signup } from "../api";
 import {
   SignupWrapper,
   SignupCard,
@@ -17,9 +18,15 @@ export default function Signup() {
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log({ email, password });
+    try {
+      await signup({ email, password });
+      alert("회원가입 성공");
+    } catch (err) {
+      console.error(err);
+      alert("회원가입 실패");
+    }
   };
 
   return (

--- a/src/pages/community/Notice.js
+++ b/src/pages/community/Notice.js
@@ -1,5 +1,27 @@
 // src/pages/community/Notice.jsx
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getNoticeList } from "../../api";
+
 export default function Notice() {
-  return <div>공지사항 페이지</div>;
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    getNoticeList()
+      .then((res) => setItems(res.content || []))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h2>공지사항</h2>
+      <ul>
+        {items.map((n) => (
+          <li key={n.id}>
+            <h3>{n.title}</h3>
+            <p>{n.content}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/pages/community/QnA.js
+++ b/src/pages/community/QnA.js
@@ -1,5 +1,62 @@
 // src/pages/community/QnA.jsx
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getQnaList, postQna } from "../../api";
+
 export default function QnA() {
-  return <div>QnA 페이지</div>;
+  const [items, setItems] = useState([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  const loadItems = () => {
+    getQnaList()
+      .then((res) => setItems(res.content || []))
+      .catch((err) => console.error(err));
+  };
+
+  useEffect(() => {
+    loadItems();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await postQna({ title, content });
+      setTitle("");
+      setContent("");
+      loadItems();
+    } catch (err) {
+      console.error(err);
+      alert("문의 등록 실패");
+    }
+  };
+
+  return (
+    <div>
+      <h2>QnA</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="제목"
+          required
+        />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="내용"
+          required
+        />
+        <button type="submit">등록</button>
+      </form>
+      <ul>
+        {items.map((q) => (
+          <li key={q.id}>
+            <h3>{q.title}</h3>
+            <p>{q.content}</p>
+            {q.answer && <p>답변: {q.answer}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- integrate API calls using a new `src/api.js`
- connect Login and Signup pages to backend endpoints
- load QnA and Notice data from backend

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b092cdd88322860070149b186e96