### PR TITLE
Fix API integration issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://13.125.148.30:8080"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "KAU",
+  "name": "KAU Program",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://13.125.148.30:8080';
+const API_BASE_URL = process.env.REACT_APP_API_URL || "";
 
 async function apiRequest(path, options = {}) {
   const response = await fetch(`${API_BASE_URL}${path}`, {


### PR DESCRIPTION
## Summary
- move API helpers to `src/api/index.js`
- add proxy config for development
- provide default manifest.json
- adjust API base URL to work with proxy

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b3e7e3a88322b91aca7683cf683e