### PR TITLE
Fix API response handling

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -14,7 +14,12 @@ async function apiRequest(path, options = {}) {
     throw new Error(message || response.statusText);
   }
   if (response.status === 204) return null;
-  return response.json();
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
 }
 
 export const getQnaList = (page = 0, size = 10) =>


### PR DESCRIPTION
## Summary
- handle API responses that return plain text instead of JSON

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b6ebc62c8322b1373b300ea8a2be