### PR TITLE
Add notice board CRUD and API debug logging

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,10 @@
 const API_BASE_URL = process.env.REACT_APP_API_URL || "";
+const DEBUG = process.env.REACT_APP_DEBUG === "true";
 
 async function apiRequest(path, options = {}) {
+  if (DEBUG) {
+    console.debug("API Request", path, options);
+  }
   const response = await fetch(`${API_BASE_URL}${path}`, {
     headers: {
       'Content-Type': 'application/json',
@@ -9,8 +13,14 @@ async function apiRequest(path, options = {}) {
     credentials: 'include',
     ...options,
   });
+  if (DEBUG) {
+    console.debug("API Response Status", response.status);
+  }
   if (!response.ok) {
     const message = await response.text();
+    if (DEBUG) {
+      console.error("API Error", message || response.statusText);
+    }
     throw new Error(message || response.statusText);
   }
   if (response.status === 204) return null;

--- a/src/pages/community/Notice.js
+++ b/src/pages/community/Notice.js
@@ -1,24 +1,110 @@
 // src/pages/community/Notice.jsx
 import React, { useEffect, useState } from "react";
-import { getNoticeList } from "../../api";
+import {
+  getNoticeList,
+  createNotice,
+  updateNotice,
+  deleteNotice,
+} from "../../api";
 
 export default function Notice() {
   const [items, setItems] = useState([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [editingId, setEditingId] = useState(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editContent, setEditContent] = useState("");
 
-  useEffect(() => {
+  const loadItems = () => {
     getNoticeList()
       .then((res) => setItems(res.content || []))
       .catch((err) => console.error(err));
+  };
+
+  useEffect(() => {
+    loadItems();
   }, []);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    try {
+      await createNotice({ title, content });
+      setTitle("");
+      setContent("");
+      loadItems();
+    } catch (err) {
+      console.error(err);
+      alert("공지 등록 실패");
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("삭제하시겠습니까?")) return;
+    try {
+      await deleteNotice(id);
+      loadItems();
+    } catch (err) {
+      console.error(err);
+      alert("삭제 실패");
+    }
+  };
+
+  const startEdit = (item) => {
+    setEditingId(item.id);
+    setEditTitle(item.title);
+    setEditContent(item.content);
+  };
+
+  const handleUpdate = async (e) => {
+    e.preventDefault();
+    try {
+      await updateNotice(editingId, { title: editTitle, content: editContent });
+      setEditingId(null);
+      setEditTitle("");
+      setEditContent("");
+      loadItems();
+    } catch (err) {
+      console.error(err);
+      alert("수정 실패");
+    }
+  };
 
   return (
     <div>
       <h2>공지사항</h2>
+      <form onSubmit={editingId ? handleUpdate : handleCreate}>
+        <input
+          value={editingId ? editTitle : title}
+          onChange={(e) =>
+            editingId ? setEditTitle(e.target.value) : setTitle(e.target.value)
+          }
+          placeholder="제목"
+          required
+        />
+        <textarea
+          value={editingId ? editContent : content}
+          onChange={(e) =>
+            editingId
+              ? setEditContent(e.target.value)
+              : setContent(e.target.value)
+          }
+          placeholder="내용"
+          required
+        />
+        <button type="submit">{editingId ? "수정" : "등록"}</button>
+        {editingId && (
+          <button type="button" onClick={() => setEditingId(null)}>
+            취소
+          </button>
+        )}
+      </form>
       <ul>
         {items.map((n) => (
           <li key={n.id}>
             <h3>{n.title}</h3>
             <p>{n.content}</p>
+            <button onClick={() => startEdit(n)}>수정</button>
+            <button onClick={() => handleDelete(n.id)}>삭제</button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- implement debug flag for API requests and log requests/responses
- extend Notice board page with create, update and delete

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c09104548322a345ccb2b25a1695