### PR TITLE
Add notice detail page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import Resources from "./pages/community/Resources";
 import Media from "./pages/community/Media";
 import Gallery from "./pages/community/Gallery";
 import QnA from "./pages/community/QnA";
+import NoticeDetail from "./pages/community/NoticeDetail";
 
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
@@ -53,6 +54,7 @@ function AppContent() {
           <Route path="/apply/form" element={<Form />} />
           <Route path="/apply/my" element={<My />} />
           <Route path="/community/notice" element={<Notice />} />
+          <Route path="/community/notice/:id" element={<NoticeDetail />} />
           <Route path="/community/resources" element={<Resources />} />
           <Route path="/community/media" element={<Media />} />
           <Route path="/community/gallery" element={<Gallery />} />

--- a/src/pages/community/Notice.js
+++ b/src/pages/community/Notice.js
@@ -1,5 +1,6 @@
 // src/pages/community/Notice.jsx
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   getNoticeList,
   createNotice,
@@ -101,7 +102,9 @@ export default function Notice() {
       <ul>
         {items.map((n) => (
           <li key={n.id}>
-            <h3>{n.title}</h3>
+            <Link to={`/community/notice/${n.id}`}>
+              <h3>{n.title}</h3>
+            </Link>
             <p>{n.content}</p>
             <button onClick={() => startEdit(n)}>수정</button>
             <button onClick={() => handleDelete(n.id)}>삭제</button>

--- a/src/pages/community/NoticeDetail.js
+++ b/src/pages/community/NoticeDetail.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { getNotice } from "../../api";
+
+export default function NoticeDetail() {
+  const { id } = useParams();
+  const [notice, setNotice] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getNotice(id)
+      .then(setNotice)
+      .catch((err) => setError(err.message));
+  }, [id]);
+
+  if (error) return <div>오류: {error}</div>;
+  if (!notice) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>{notice.title}</h2>
+      <p>{notice.content}</p>
+      <Link to="/community/notice">목록으로</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- display notice details in new page
- link each notice to its detail page
- route notice details in the app

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c3da07188322b15b5b108a46031f