### PR TITLE
Add simple JWT auth server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,12 @@ This project is a React web application for the KAU program. To run or test the 
    ```
    The first run may fail if packages like `react-scripts` are missing, so always run `npm install` beforehand.
 
+4. Run the sample authentication server:
+   ```bash
+   cd server
+   npm install
+   npm start
+   ```
+   This Express server issues JWT tokens on `/api/login` and stores them in an `HttpOnly` cookie. API requests from the React app are proxied to `http://localhost:8080`.
+
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,50 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+const PORT = process.env.PORT || 8080;
+const JWT_SECRET = process.env.JWT_SECRET || 'change_this_secret';
+
+app.use(express.json());
+app.use(cookieParser());
+
+const dummyUser = {
+  id: 1,
+  email: 'test@example.com',
+  password: 'password'
+};
+
+app.post('/api/login', (req, res) => {
+  const { email, password } = req.body;
+  if (email === dummyUser.email && password === dummyUser.password) {
+    const token = jwt.sign({ id: dummyUser.id, email: dummyUser.email }, JWT_SECRET, { expiresIn: '1h' });
+    res.cookie('token', token, { httpOnly: true, sameSite: 'lax' });
+    return res.json({ id: dummyUser.id, email: dummyUser.email });
+  }
+  res.status(401).json({ error: 'Invalid credentials' });
+});
+
+function authenticate(req, res, next) {
+  const token = req.cookies.token;
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    req.user = jwt.verify(token, JWT_SECRET);
+    return next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+app.get('/api/profile', authenticate, (req, res) => {
+  res.json({ user: req.user });
+});
+
+app.post('/api/logout', (req, res) => {
+  res.clearCookie('token');
+  res.sendStatus(204);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kau-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "express": "^4.19.0",
+    "jsonwebtoken": "^9.0.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express-based server that issues JWT tokens on login and stores them as HTTP-only cookies
- document how to run the new authentication server

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842de01414c8322857c277aa3bfd891